### PR TITLE
Update PUT URL to include p_guid

### DIFF
--- a/lib/icloud/session.rb
+++ b/lib/icloud/session.rb
@@ -85,6 +85,15 @@ module ICloud
       })
     end
 
+    def put_collection_reminder(reminder)
+      ensure_logged_in
+
+      post(service_url(:reminders, "/rd/reminders/#{reminder.p_guid}"), { "methodOverride" => "PUT" }, {
+        "Reminders" => reminder.to_icloud,
+        "ClientState" => client_state
+      })
+    end
+
     def delete_reminder(reminder)
       ensure_logged_in
 


### PR DESCRIPTION
`master` PUT/POSTs to `path: /rd/reminders/tasks`, which - at least in my account - is 404ing with any set of arguments, including an unmodified Reminder. In a graphical browser, I can see that all PUTs and POSTs that I can generate (completing, creating, editing) go to `/pd/reminders/#{p_guid}` with no delimiters, like:

    /rd/reminders/1234b0e462ac58bbb43b00cb340816f42aad99f5d247d0aacf780d3620978e8f

My suspicion is that all of the Reminder-specific URLs should change to this, but I added it as a new method to be safe since:

* I don't know all intended uses of `put_reminder`/`post_reminder`, and
* My captures from a browser were far from exhaustive

I can say that calling this method/URL with a reminder that has `completed_date` set does complete the reminder and that as of today, that's what iCloud itself does in at least Chrome.